### PR TITLE
Workaround isort bug

### DIFF
--- a/molecule_containers/test/functional/test_containers.py
+++ b/molecule_containers/test/functional/test_containers.py
@@ -19,6 +19,8 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 """Functional Tests."""
+# https://github.com/PyCQA/isort/issues/1790
+# isort:skip_file
 import os
 
 from molecule.test.conftest import change_dir_to, molecule_directory


### PR DESCRIPTION
Disable isort for particular file due to reported bug.

Related: https://github.com/PyCQA/isort/issues/1790